### PR TITLE
docs: correct logging path references

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -21,10 +21,10 @@ work captured in `specs/003-compile/tasks.md` (T027).
 
 | Stage            | Location                                             | Notes                                     |
 |------------------|------------------------------------------------------|-------------------------------------------|
-| Parsing          | `fp-cli/src/pipeline.rs:parse_source`                | Emits source path and module count        |
-| Type Enrichment  | `fp-cli/src/pipeline.rs:run_type_enrichment_stage`   | Logs typed AST cloning and HIR output     |
-| Const Evaluation | `fp-cli/src/pipeline.rs:run_const_eval_stage`        | Logs stubbed const-eval (AST focus)       |
-| HIR Emission     | `fp-backend/src/transformations/ast_to_hir.rs`      | Span-preserving logs, TODO for modules    |
+| Parsing          | `crates/fp-cli/src/pipeline.rs:parse_source`                | Emits source path and module count        |
+| Type Enrichment  | `crates/fp-cli/src/pipeline.rs:run_type_enrichment_stage`   | Logs typed AST cloning and HIR output     |
+| Const Evaluation | `crates/fp-cli/src/pipeline.rs:run_const_eval_stage`        | Logs stubbed const-eval (AST focus)       |
+| HIR Emission     | `crates/fp-backend/src/transforms/ast_to_hir/mod.rs`        | Span-preserving logs, TODO for modules    |
 | Future Backends  | _pending rewrite_                                    | MIR/LIR/LLVM hooks will return once ready |
 
 ## Tracing Roadmap (T027)


### PR DESCRIPTION
## Summary
- update logging doc paths to match current crate layout

## Testing
- not run (docs-only change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected logging path references in Logging.md to match the current crates layout, so readers can locate pipeline and HIR emission logs accurately. Updates include fp-cli stage paths and the HIR emission path now at crates/fp-backend/src/transforms/ast_to_hir/mod.rs.

<sup>Written for commit c12e1d1f9050ffc1ac9195aae119d8c504549db7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

