### PR TITLE
feat(cli): add log level + format flags

### DIFF
--- a/crates/fp-cli/Cargo.toml
+++ b/crates/fp-cli/Cargo.toml
@@ -46,7 +46,7 @@ globset = "0.4"
 
 # Logging and diagnostics
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 termwiz = "0.23.3"
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -32,14 +32,14 @@ work captured in `specs/003-compile/tasks.md` (T027).
 1. **Structured Spans** – Introduce span guards for each pipeline step so nested operations (e.g., module lowering) are visible.
 2. **File/Module Attribution** – Include module names and `NodeId` references in logs for easier correlation with typed AST/HIR outputs.
 3. **Error Correlation** – Ensure errors recorded through `tracing::error!` map back to TAST spans, matching the cross-stage guarantees.
-4. **CLI Flags** – Add `--log {level}` and `--log-format {pretty,json}` flags with sensible defaults.
+4. **CLI Flags** – Added `--log {error|warn|info|debug|trace}` and `--log-format {pretty,json}` flags with sensible defaults.
 5. **Test Hooks** – Provide utilities in `fp-backend/tests` to assert log spans when running pipeline tests.
 
 ## Current Status
 
 - T027 is **in progress**: pipeline stages now emit `tracing` spans (`pipeline.const_eval`, `pipeline.lower.*`,
   `pipeline.codegen`, etc.) with debug events for persisted intermediates.
-- Remaining work: expose CLI/ENV controls, add JSON formatter, and propagate span context into optimisation crates.
+- Remaining work: propagate span context into optimisation crates.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- add --log {error|warn|info|debug|trace} to override verbose/quiet
- add --log-format {pretty,json} and wire JSON formatter
- update logging docs

## Testing
- not run (cli/docs change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global CLI flags to control logging: --log {error|warn|info|debug|trace} and --log-format {pretty|json}. JSON formatting is wired via tracing_subscriber.

- **New Features**
  - --log overrides --verbose/--quiet; maps to EnvFilter levels.
  - --log-format defaults to pretty; JSON uses fmt.json; Cargo enables the json feature.
  - Flags are global and implemented with clap ValueEnum; Logging.md updated.

<sup>Written for commit e31451a672380f02c9b0719a545c0644ffcb402e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

