### PR TITLE
Fix rustfmt issues to restore CI

### DIFF
--- a/crates/fp-backend/src/lib.rs
+++ b/crates/fp-backend/src/lib.rs
@@ -5,8 +5,8 @@
 // - queries: Stateless operations for extracting information
 // - utils: Shared utilities and helper components
 
-pub mod error;
 pub mod abi;
+pub mod error;
 pub mod optimizer;
 pub mod transforms;
 

--- a/crates/fp-backend/src/transforms/ast_to_hir/helpers.rs
+++ b/crates/fp-backend/src/transforms/ast_to_hir/helpers.rs
@@ -169,11 +169,8 @@ impl HirGenerator {
                 PathResolutionScope::Type => self.resolve_type_symbol(name).is_some(),
             };
             if let Some(ctx) = &self.module_resolution {
-                if let Some(qualified) = resolve_symbol_path(
-                    &parsed,
-                    ctx,
-                    scope_contains,
-                    |candidate| {
+                if let Some(qualified) =
+                    resolve_symbol_path(&parsed, ctx, scope_contains, |candidate| {
                         let key = candidate.path.to_key();
                         match scope {
                             PathResolutionScope::Value => {
@@ -195,13 +192,11 @@ impl HirGenerator {
                             }
                         }
                         false
-                    },
-                ) {
+                    })
+                {
                     let canonical = qualified.path;
-                    let mut canonical_segments =
-                        Vec::with_capacity(canonical.segments.len());
-                    let offset =
-                        canonical.segments.len().saturating_sub(segments.len());
+                    let mut canonical_segments = Vec::with_capacity(canonical.segments.len());
+                    let offset = canonical.segments.len().saturating_sub(segments.len());
                     for (idx, seg) in canonical.segments.iter().enumerate() {
                         let args = if idx >= offset {
                             segments[idx - offset].args.clone()
@@ -210,8 +205,7 @@ impl HirGenerator {
                         };
                         canonical_segments.push(self.make_path_segment(seg, args));
                     }
-                    let mut canonical_res =
-                        self.lookup_global_res(&canonical, scope);
+                    let mut canonical_res = self.lookup_global_res(&canonical, scope);
                     if canonical_res.is_none() && self.module_defs.contains(&canonical) {
                         canonical_res = Some(hir::Res::Module(canonical.segments.clone()));
                     }
@@ -286,7 +280,11 @@ impl HirGenerator {
                 PathPrefix::Root | PathPrefix::Crate => Vec::new(),
                 PathPrefix::SelfMod => self.module_path.segments.clone(),
                 PathPrefix::Super(depth) => {
-                    let keep = self.module_path.segments.len().saturating_sub(depth as usize);
+                    let keep = self
+                        .module_path
+                        .segments
+                        .len()
+                        .saturating_sub(depth as usize);
                     self.module_path.segments[..keep].to_vec()
                 }
                 PathPrefix::Plain => Vec::new(),

--- a/crates/fp-backend/src/transforms/hir_to_mir/expr.rs
+++ b/crates/fp-backend/src/transforms/hir_to_mir/expr.rs
@@ -5117,10 +5117,7 @@ impl<'a> BodyBuilder<'a> {
         span: Span,
     ) -> Result<()> {
         let init_span = init.as_ref().map(|expr| expr.span).unwrap_or(span);
-        let ty_is_infer = matches!(
-            ty.kind,
-            hir::TypeExprKind::Infer | hir::TypeExprKind::Error
-        );
+        let ty_is_infer = matches!(ty.kind, hir::TypeExprKind::Infer | hir::TypeExprKind::Error);
         let mut declared_ty = if ty_is_infer {
             None
         } else {
@@ -5197,7 +5194,12 @@ impl<'a> BodyBuilder<'a> {
                 declared_ty.as_ref(),
                 init_expr,
             );
-            self.lower_assignment(local_id, declared_ty.as_ref(), annotated_enum_def, init_expr)?;
+            self.lower_assignment(
+                local_id,
+                declared_ty.as_ref(),
+                annotated_enum_def,
+                init_expr,
+            )?;
         }
 
         Ok(())
@@ -9388,10 +9390,8 @@ impl<'a> BodyBuilder<'a> {
                 let target_ty = self.lower_type_expr(ty_expr);
                 if let hir::ExprKind::Literal(hir::Lit::Integer(value)) = &inner.kind {
                     if matches!(target_ty.kind, TyKind::Int(_) | TyKind::Uint(_)) {
-                        let (literal, ty) = self.lower_literal(
-                            &hir::Lit::Integer(*value),
-                            Some(&target_ty),
-                        );
+                        let (literal, ty) =
+                            self.lower_literal(&hir::Lit::Integer(*value), Some(&target_ty));
                         return Ok(OperandInfo {
                             operand: mir::Operand::Constant(mir::Constant {
                                 span: expr.span,

--- a/crates/fp-backend/src/transforms/mir_to_lir/instr.rs
+++ b/crates/fp-backend/src/transforms/mir_to_lir/instr.rs
@@ -2039,9 +2039,7 @@ impl LirGenerator {
                         self.lir_type_from_ty(ty),
                     ))
                 }
-            mir::ConstantKind::Str(s) => {
-                    Ok(lir::LirValue::Constant(self.const_string_ptr(s)))
-            }
+                mir::ConstantKind::Str(s) => Ok(lir::LirValue::Constant(self.const_string_ptr(s))),
                 mir::ConstantKind::Int(value) => Ok(lir::LirValue::Constant(
                     lir::LirConstant::Int(*value, lir::LirType::I64),
                 )),
@@ -4332,13 +4330,19 @@ impl LirGenerator {
 
         if let Some((dest_place, dest_bb)) = destination.as_ref() {
             if let Some(ref ty) = result_type {
-                if matches!(ty, lir::LirType::Struct { .. } | lir::LirType::Array(_, _) | lir::LirType::Vector(_, _)) {
+                if matches!(
+                    ty,
+                    lir::LirType::Struct { .. }
+                        | lir::LirType::Array(_, _)
+                        | lir::LirType::Vector(_, _)
+                ) {
                     let alignment = Self::alignment_for_lir_type(ty);
                     let ptr = if let Some(storage) = self.local_storage.get(&dest_place.local) {
                         storage.ptr_value.clone()
                     } else {
                         let pointer_type = lir::LirType::Ptr(Box::new(ty.clone()));
-                        let size_value = lir::LirValue::Constant(lir::LirConstant::Int(1, lir::LirType::I32));
+                        let size_value =
+                            lir::LirValue::Constant(lir::LirConstant::Int(1, lir::LirType::I32));
                         let alloca_id = self.next_id();
                         block.instructions.push(lir::LirInstruction {
                             id: alloca_id,

--- a/crates/fp-cli/src/commands/compile.rs
+++ b/crates/fp-cli/src/commands/compile.rs
@@ -10,8 +10,8 @@ use crate::{
     pipeline::{Pipeline, PipelineInput, PipelineOutput},
 };
 use console::style;
-use fp_core::config;
 use fp_core::ast::{AstTarget, AstTargetOutput, Node};
+use fp_core::config;
 use fp_csharp::CSharpSerializer;
 use fp_golang::GoSerializer;
 use fp_lang::PrettyAstSerializer;
@@ -170,10 +170,7 @@ pub async fn compile_command(args: CompileArgs, config: &CliConfig) -> Result<()
         CompileTarget::Backend(backend) => backend.as_str().to_string(),
         CompileTarget::Ast(ast_target) => format!("{:?}", ast_target),
     };
-    info!(
-        "Starting compilation with target: {}",
-        target_label
-    );
+    info!("Starting compilation with target: {}", target_label);
 
     // Validate inputs
     validate_inputs(&args)?;
@@ -218,8 +215,8 @@ async fn compile_once(args: CompileArgs, config: &CliConfig) -> Result<()> {
         )?;
 
         // Compile single file
-        if let Some(artifact_path) = compile_file(input_file, &output_file, &args, target, config)
-            .await?
+        if let Some(artifact_path) =
+            compile_file(input_file, &output_file, &args, target, config).await?
         {
             compiled_files.push(artifact_path);
         }
@@ -597,7 +594,10 @@ fn is_package_manifest(path: &Path) -> bool {
         .and_then(|name| name.to_str())
         .map(|name| {
             let lower = name.to_ascii_lowercase();
-            matches!(lower.as_str(), "cargo.toml" | "package.json" | "magnet.toml")
+            matches!(
+                lower.as_str(),
+                "cargo.toml" | "package.json" | "magnet.toml"
+            )
         })
         .unwrap_or(false)
 }
@@ -701,10 +701,9 @@ fn determine_output_path(
             let extension = crate::languages::backend::ast_output_extension_for(ast_target);
             if let Some(output) = output {
                 if output_is_dir {
-                    let stem = input
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .ok_or_else(|| CliError::InvalidInput("Invalid input filename".to_string()))?;
+                    let stem = input.file_stem().and_then(|s| s.to_str()).ok_or_else(|| {
+                        CliError::InvalidInput("Invalid input filename".to_string())
+                    })?;
                     let mut path = output.join(stem);
                     path.set_extension(extension);
                     return Ok(path);

--- a/crates/fp-cli/src/commands/eval.rs
+++ b/crates/fp-cli/src/commands/eval.rs
@@ -1,8 +1,6 @@
 //! Expression evaluation command implementation
 
-use crate::pipeline::{
-    BackendKind, DebugOptions, LossyOptions, PipelineOptions, RuntimeConfig,
-};
+use crate::pipeline::{BackendKind, DebugOptions, LossyOptions, PipelineOptions, RuntimeConfig};
 use crate::{
     CliError, Result,
     cli::CliConfig,
@@ -71,7 +69,9 @@ async fn eval_single(input: PipelineInput, description: &str, args: &EvalArgs) -
     let output = match input {
         PipelineInput::Expression(_) => {
             options.disabled_stages.push("const-eval".to_string());
-            options.disabled_stages.push("intrinsic-normalize".to_string());
+            options
+                .disabled_stages
+                .push("intrinsic-normalize".to_string());
             pipeline.execute_with_options(input, options).await?
         }
         _ => pipeline.execute_with_options(input, options).await?,

--- a/crates/fp-cli/src/commands/run.rs
+++ b/crates/fp-cli/src/commands/run.rs
@@ -30,9 +30,7 @@ pub async fn run_command(args: RunArgs, config: &CliConfig) -> Result<()> {
     crate::commands::validate_paths_exist(&[args.file.clone()], true, "run")?;
 
     if matches!(args.mode, RunMode::Interpret) {
-        let interpret_args = InterpretArgs {
-            input: args.file,
-        };
+        let interpret_args = InterpretArgs { input: args.file };
         return interpret_command(interpret_args, config).await;
     }
 

--- a/crates/fp-cli/src/diagnostics.rs
+++ b/crates/fp-cli/src/diagnostics.rs
@@ -184,7 +184,9 @@ fn core_diagnostic_to_report(diag: &CoreDiagnostic) -> Report {
     Report::new(error)
 }
 
-fn core_diagnostic_source(diag: &CoreDiagnostic) -> (Option<NamedSource<String>>, Option<SourceSpan>) {
+fn core_diagnostic_source(
+    diag: &CoreDiagnostic,
+) -> (Option<NamedSource<String>>, Option<SourceSpan>) {
     let Some(span) = diag.span else {
         return (None, None);
     };
@@ -239,7 +241,9 @@ impl std::error::Error for CoreMietteDiagnostic {}
 
 impl Diagnostic for CoreMietteDiagnostic {
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.code.as_ref().map(|code| Box::new(code.clone()) as Box<dyn Display>)
+        self.code
+            .as_ref()
+            .map(|code| Box::new(code.clone()) as Box<dyn Display>)
     }
 
     fn severity(&self) -> Option<Severity> {
@@ -253,9 +257,7 @@ impl Diagnostic for CoreMietteDiagnostic {
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        self.source
-            .as_ref()
-            .map(|source| source as &dyn SourceCode)
+        self.source.as_ref().map(|source| source as &dyn SourceCode)
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {

--- a/crates/fp-cli/src/languages/frontend.rs
+++ b/crates/fp-cli/src/languages/frontend.rs
@@ -1,12 +1,12 @@
 pub use fp_core::frontend::{FrontendResult, FrontendSnapshot, LanguageFrontend};
 pub use fp_flatbuffers::FlatbuffersFrontend;
+pub use fp_golang::GoFrontend;
 pub use fp_hcl::HclFrontend;
 pub use fp_json::JsonFrontend;
 pub use fp_jsonschema::JsonSchemaFrontend;
 pub use fp_lang::FerroFrontend;
 pub use fp_prql::PrqlFrontend;
 pub use fp_python::PythonFrontend;
-pub use fp_golang::GoFrontend;
 pub use fp_sql::SqlFrontend;
 pub use fp_toml::TomlFrontend;
 pub use fp_typescript::TypeScriptFrontend;

--- a/crates/fp-cli/src/pipeline/diagnostics.rs
+++ b/crates/fp-cli/src/pipeline/diagnostics.rs
@@ -1,5 +1,5 @@
-use fp_core::diagnostics::{Diagnostic, DiagnosticDisplayOptions, DiagnosticLevel};
 use crate::diagnostics::render_core_diagnostic;
+use fp_core::diagnostics::{Diagnostic, DiagnosticDisplayOptions, DiagnosticLevel};
 
 use super::PipelineOptions;
 

--- a/crates/fp-cli/src/pipeline/mod.rs
+++ b/crates/fp-cli/src/pipeline/mod.rs
@@ -1,9 +1,9 @@
 use crate::CliError;
 use crate::codegen::CodeGenerator;
 use crate::languages::frontend::{
-    FerroFrontend, FlatbuffersFrontend, FrontendResult, FrontendSnapshot, HclFrontend,
-    JsonFrontend, JsonSchemaFrontend, LanguageFrontend, PrqlFrontend, PythonFrontend, GoFrontend,
-    SqlFrontend, TomlFrontend, TypeScriptFrontend, WitFrontend,
+    FerroFrontend, FlatbuffersFrontend, FrontendResult, FrontendSnapshot, GoFrontend, HclFrontend,
+    JsonFrontend, JsonSchemaFrontend, LanguageFrontend, PrqlFrontend, PythonFrontend, SqlFrontend,
+    TomlFrontend, TypeScriptFrontend, WitFrontend,
 };
 use crate::languages::{self, detect_source_language};
 use fp_backend::transformations::{HirGenerator, LirGenerator, MirLowering};
@@ -43,9 +43,7 @@ mod options;
 mod stages;
 use self::diagnostics as diag;
 use artifacts::LlvmArtifacts;
-pub use options::{
-    BackendKind, DebugOptions, LossyOptions, PipelineOptions, RuntimeConfig,
-};
+pub use options::{BackendKind, DebugOptions, LossyOptions, PipelineOptions, RuntimeConfig};
 
 const STAGE_FRONTEND: &str = "frontend";
 const STAGE_CONST_EVAL: &str = "const-eval";
@@ -425,9 +423,7 @@ impl Pipeline {
             Ok(result) => result,
             Err(err) => {
                 if let fp_core::error::Error::Diagnostic(diag) = &err {
-                    let diag = diag
-                        .clone()
-                        .with_source_context(STAGE_FRONTEND.to_string());
+                    let diag = diag.clone().with_source_context(STAGE_FRONTEND.to_string());
                     diag::emit(&[diag], Some(STAGE_FRONTEND), options);
                     return Err(Self::stage_failure(STAGE_FRONTEND));
                 }
@@ -754,11 +750,8 @@ impl Pipeline {
                     } else if backend == "cranelift" || backend == "fp-cranelift" {
                         let stage_started = std::time::Instant::now();
                         info!("pipeline: start {}", STAGE_LINK_BINARY);
-                        let binary_path = self.stage_link_binary_cranelift(
-                            &lir.lir_program,
-                            base_path,
-                            options,
-                        )?;
+                        let binary_path =
+                            self.stage_link_binary_cranelift(&lir.lir_program, base_path, options)?;
                         info!(
                             "pipeline: finished {} in {:.2?}",
                             STAGE_LINK_BINARY,

--- a/crates/fp-cli/src/pipeline/stages/link.rs
+++ b/crates/fp-cli/src/pipeline/stages/link.rs
@@ -327,10 +327,7 @@ fn link_object_with_clang(
     diagnostics: &mut PipelineDiagnostics,
     extra_inputs: &[PathBuf],
 ) -> Result<(), PipelineError> {
-    let linker = options
-        .linker
-        .as_deref()
-        .unwrap_or("clang");
+    let linker = options.linker.as_deref().unwrap_or("clang");
     let mut cmd = Command::new(linker);
     cmd.arg(object_path);
     for input in extra_inputs {

--- a/crates/fp-cli/src/pipeline/stages/lowering.rs
+++ b/crates/fp-cli/src/pipeline/stages/lowering.rs
@@ -1,8 +1,8 @@
 use super::super::artifacts::{LirArtifacts, MirArtifacts};
 use super::super::*;
 use fp_backend::optimizer::{MirOptimizer, OptimizationPlan};
-use fp_core::mir;
 use fp_core::config;
+use fp_core::mir;
 use fp_llvm::target::{OptimizationLevel, TargetConfig};
 use fp_pipeline::{PipelineDiagnostics, PipelineError, PipelineStage};
 use std::sync::Arc;

--- a/crates/fp-cli/src/pipeline/stages/materialize.rs
+++ b/crates/fp-cli/src/pipeline/stages/materialize.rs
@@ -27,7 +27,8 @@ impl PipelineStage for MaterializeStage {
         context: MaterializeContext,
         diagnostics: &mut PipelineDiagnostics,
     ) -> Result<Node, PipelineError> {
-        let materializer = IntrinsicsMaterializer::for_target(&context.target, context.backend.as_deref());
+        let materializer =
+            IntrinsicsMaterializer::for_target(&context.target, context.backend.as_deref());
         let mut ast = context.ast;
         match materializer.materialize(&mut ast) {
             Ok(()) => Ok(ast),

--- a/crates/fp-cli/src/pipeline/stages/normalize.rs
+++ b/crates/fp-cli/src/pipeline/stages/normalize.rs
@@ -1,6 +1,6 @@
 use super::super::*;
-use fp_pipeline::{PipelineDiagnostics, PipelineError, PipelineStage};
 use fp_core::ast::{File, ItemKind, Node, NodeKind};
+use fp_pipeline::{PipelineDiagnostics, PipelineError, PipelineStage};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -88,7 +88,10 @@ impl Pipeline {
                     let base_dir = std_path.parent().unwrap_or_else(|| Path::new("."));
                     let mut loader = FileModuleLoader::new(self, options, &frontend);
                     let items = loader.resolve_items(&file.items, base_dir)?;
-                    std_node = Node::file(File { path: file.path, items });
+                    std_node = Node::file(File {
+                        path: file.path,
+                        items,
+                    });
                 }
                 merged = merge_std_module(
                     merged,

--- a/crates/fp-cli/src/pipeline/stages/typing.rs
+++ b/crates/fp-cli/src/pipeline/stages/typing.rs
@@ -1,6 +1,6 @@
 use super::super::*;
-use fp_pipeline::{PipelineDiagnostics, PipelineError, PipelineStage};
 use fp_core::config;
+use fp_pipeline::{PipelineDiagnostics, PipelineError, PipelineStage};
 
 pub(crate) struct TypingContext {
     pub ast: Node,

--- a/crates/fp-cli/src/utils/file_utils.rs
+++ b/crates/fp-cli/src/utils/file_utils.rs
@@ -155,8 +155,8 @@ impl FileWatcher {
     pub fn check_for_changes(&mut self) -> Result<Vec<PathBuf>> {
         let mut changed_files = Vec::new();
 
-        self.watched_files.retain(|file| {
-            match FileUtils::modification_time(file) {
+        self.watched_files
+            .retain(|file| match FileUtils::modification_time(file) {
                 Ok(current_time) => {
                     if let Some(&last_time) = self.last_modified.get(file) {
                         if current_time > last_time {
@@ -174,8 +174,7 @@ impl FileWatcher {
                     false
                 }
                 Err(_) => true,
-            }
-        });
+            });
 
         Ok(changed_files)
     }

--- a/crates/fp-cli/tests/integration_tests.rs
+++ b/crates/fp-cli/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 
 use assert_cmd::Command;
 use fp_cli::cli::CliConfig;
-use fp_cli::commands::compile::{compile_command, CompileArgs, EmitterKind};
+use fp_cli::commands::compile::{CompileArgs, EmitterKind, compile_command};
 use fp_cli::pipeline::BackendKind;
 use predicates::prelude::*;
 use std::fs;

--- a/crates/fp-cli/tests/test_compile_ast_target.rs
+++ b/crates/fp-cli/tests/test_compile_ast_target.rs
@@ -144,7 +144,10 @@ fn main() {
     assert!(result.is_ok(), "TypeScript target should succeed");
 
     assert!(output_file.exists(), "Output file should be created");
-    assert!(defs_file.exists(), "Type definitions file should be created");
+    assert!(
+        defs_file.exists(),
+        "Type definitions file should be created"
+    );
 
     let defs_content = fs::read_to_string(&defs_file).unwrap();
     assert!(defs_content.contains("interface User"));

--- a/crates/fp-core/src/cfg.rs
+++ b/crates/fp-core/src/cfg.rs
@@ -27,10 +27,7 @@ pub fn filter_items_in_node(node: &mut Node, env: &TargetEnv) {
         NodeKind::Item(item) => {
             filter_item(item, env);
         }
-        NodeKind::Expr(_)
-        | NodeKind::Query(_)
-        | NodeKind::Schema(_)
-        | NodeKind::Workspace(_) => {}
+        NodeKind::Expr(_) | NodeKind::Query(_) | NodeKind::Schema(_) | NodeKind::Workspace(_) => {}
     }
 }
 

--- a/crates/fp-core/src/lib.rs
+++ b/crates/fp-core/src/lib.rs
@@ -4,8 +4,8 @@
 pub mod macros;
 
 pub mod ast;
-pub mod collections;
 pub mod cfg;
+pub mod collections;
 pub mod config;
 pub mod context;
 pub mod cst;

--- a/crates/fp-core/src/module/resolution.rs
+++ b/crates/fp-core/src/module/resolution.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::module::path::{ParsedPath, PathPrefix, QualifiedPath};
-use crate::module::{ModuleId, ModuleDescriptor};
 use crate::module::resolver::ResolverRegistry;
+use crate::module::{ModuleDescriptor, ModuleId};
 use crate::package::graph::PackageGraph;
 use crate::package::PackageId;
 
@@ -37,7 +37,8 @@ pub fn resolve_symbol_path(
 ) -> Option<QualifiedSymbol> {
     let module_id = ctx.current_module.as_ref()?;
     let module = ctx.graph.module(module_id)?;
-    let (package_id, base_segments, raw_segments) = resolve_base_segments(parsed, module, &ctx.graph)?;
+    let (package_id, base_segments, raw_segments) =
+        resolve_base_segments(parsed, module, &ctx.graph)?;
 
     if raw_segments.is_empty() {
         return None;
@@ -74,11 +75,9 @@ fn resolve_base_segments(
     }
 
     match parsed.prefix {
-        PathPrefix::Root | PathPrefix::Crate => Some((
-            module.package.clone(),
-            Vec::new(),
-            parsed.segments.clone(),
-        )),
+        PathPrefix::Root | PathPrefix::Crate => {
+            Some((module.package.clone(), Vec::new(), parsed.segments.clone()))
+        }
         PathPrefix::SelfMod => Some((
             module.package.clone(),
             module.module_path.clone(),

--- a/crates/fp-core/src/query/mod.rs
+++ b/crates/fp-core/src/query/mod.rs
@@ -302,7 +302,10 @@ pub fn split_sql_statements(source: &str) -> Vec<String> {
             if !text.is_empty() {
                 statements.push(text.to_string());
             }
-            let end = offsets.get(idx + 1).copied().unwrap_or_else(|| source.len());
+            let end = offsets
+                .get(idx + 1)
+                .copied()
+                .unwrap_or_else(|| source.len());
             current_start = end;
         }
     }
@@ -327,10 +330,7 @@ fn split_sql_statements_fallback(source: &str) -> Vec<String> {
     while let Some(ch) = chars.next() {
         match ch {
             '\'' if !double_quote && !backtick => {
-                if single_quote
-                    && prev_char != Some('\\')
-                    && chars.peek().copied() == Some('\'')
-                {
+                if single_quote && prev_char != Some('\\') && chars.peek().copied() == Some('\'') {
                     current.push(ch);
                     current.push(chars.next().unwrap());
                 } else if prev_char != Some('\\') {
@@ -341,10 +341,7 @@ fn split_sql_statements_fallback(source: &str) -> Vec<String> {
                 }
             }
             '"' if !single_quote && !backtick => {
-                if double_quote
-                    && prev_char != Some('\\')
-                    && chars.peek().copied() == Some('"')
-                {
+                if double_quote && prev_char != Some('\\') && chars.peek().copied() == Some('"') {
                     current.push(ch);
                     current.push(chars.next().unwrap());
                 } else if prev_char != Some('\\') {
@@ -457,7 +454,11 @@ mod tests {
     fn split_sql_statements_handles_escaped_quotes() {
         let source = "SELECT 'a''b;still'; SELECT \"c\"\"d;still\";";
         let statements = split_sql_statements(source);
-        assert_eq!(statements.len(), 2, "expected two statements: {statements:?}");
+        assert_eq!(
+            statements.len(),
+            2,
+            "expected two statements: {statements:?}"
+        );
         assert_eq!(statements[0], "SELECT 'a''b;still'");
         assert_eq!(statements[1], "SELECT \"c\"\"d;still\"");
     }

--- a/crates/fp-cranelift/src/config.rs
+++ b/crates/fp-cranelift/src/config.rs
@@ -107,4 +107,3 @@ impl CraneliftConfig {
         self
     }
 }
-

--- a/crates/fp-cranelift/src/lib.rs
+++ b/crates/fp-cranelift/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod config;
 mod codegen;
+pub mod config;
 
-use crate::config::{CraneliftConfig, EmitKind};
 use crate::codegen::CraneliftBackend;
+use crate::config::{CraneliftConfig, EmitKind};
 use fp_core::error::Result;
 use fp_core::lir::LirProgram;
 use std::path::{Path, PathBuf};

--- a/crates/fp-golang/src/parser.rs
+++ b/crates/fp-golang/src/parser.rs
@@ -3,7 +3,7 @@
 //! This parser maps a small subset of Go syntax into FerroPhase AST so the
 //! Go backend can provide basic parsing support.
 
-use eyre::{Result, eyre};
+use eyre::{eyre, Result};
 use fp_core::ast::{
     BlockStmt, BlockStmtExpr, Expr, ExprBlock, ExprKind, ExprReturn, File, Ident, Item,
     ItemDefConst, ItemDefFunction, ItemDefStruct, ItemDefType, ItemImport, ItemImportPath,
@@ -11,8 +11,8 @@ use fp_core::ast::{
     TypePrimitive, TypeTuple, TypeVec, Value, Visibility,
 };
 use fp_core::span::Span;
-use tree_sitter::{Node as TsNode, Parser as TsParser};
 use tracing::warn;
+use tree_sitter::{Node as TsNode, Parser as TsParser};
 
 /// High-level parser that owns a tree-sitter instance for Go.
 pub struct GoParser {
@@ -536,18 +536,27 @@ fn parse_numeric_literal(node: TsNode, source: &str) -> Result<Expr> {
     let normalized = raw.replace('_', "");
 
     if normalized.starts_with("0x") || normalized.starts_with("0X") {
-        let value = i64::from_str_radix(normalized.trim_start_matches("0x").trim_start_matches("0X"), 16)
-            .map_err(|err| eyre!("invalid hex literal {raw}: {err}"))?;
+        let value = i64::from_str_radix(
+            normalized.trim_start_matches("0x").trim_start_matches("0X"),
+            16,
+        )
+        .map_err(|err| eyre!("invalid hex literal {raw}: {err}"))?;
         return Ok(Expr::value(Value::int(value)));
     }
     if normalized.starts_with("0b") || normalized.starts_with("0B") {
-        let value = i64::from_str_radix(normalized.trim_start_matches("0b").trim_start_matches("0B"), 2)
-            .map_err(|err| eyre!("invalid binary literal {raw}: {err}"))?;
+        let value = i64::from_str_radix(
+            normalized.trim_start_matches("0b").trim_start_matches("0B"),
+            2,
+        )
+        .map_err(|err| eyre!("invalid binary literal {raw}: {err}"))?;
         return Ok(Expr::value(Value::int(value)));
     }
     if normalized.starts_with("0o") || normalized.starts_with("0O") {
-        let value = i64::from_str_radix(normalized.trim_start_matches("0o").trim_start_matches("0O"), 8)
-            .map_err(|err| eyre!("invalid octal literal {raw}: {err}"))?;
+        let value = i64::from_str_radix(
+            normalized.trim_start_matches("0o").trim_start_matches("0O"),
+            8,
+        )
+        .map_err(|err| eyre!("invalid octal literal {raw}: {err}"))?;
         return Ok(Expr::value(Value::int(value)));
     }
 

--- a/crates/fp-golang/src/serializer.rs
+++ b/crates/fp-golang/src/serializer.rs
@@ -6,8 +6,8 @@ use fp_core::ast::{
     AstSerializer, BlockStmt, BlockStmtExpr, Expr, ExprBlock, ExprIntrinsicCall, ExprInvoke,
     ExprInvokeTarget, ExprKind, File, Item, ItemDefConst, ItemDefEnum, ItemDefFunction,
     ItemDefStruct, ItemDefType, ItemImport, ItemImportPath, ItemImportRename, ItemImportTree,
-    ItemKind, Node, NodeKind, PatternKind, Ty, TypeArray, TypePrimitive, TypeTuple, TypeVec,
-    Value, ValueStruct, ValueTuple,
+    ItemKind, Node, NodeKind, PatternKind, Ty, TypeArray, TypePrimitive, TypeTuple, TypeVec, Value,
+    ValueStruct, ValueTuple,
 };
 use fp_core::error::Result;
 use fp_core::intrinsics::IntrinsicCallKind;
@@ -69,12 +69,10 @@ impl GoEmitter {
     fn emit_node(&mut self, node: &Node) -> Result<()> {
         match node.kind() {
             NodeKind::File(file) => self.emit_file(file),
-            NodeKind::Item(item) => {
-                self.emit_file(&File {
-                    path: Default::default(),
-                    items: vec![item.clone()],
-                })
-            }
+            NodeKind::Item(item) => self.emit_file(&File {
+                path: Default::default(),
+                items: vec![item.clone()],
+            }),
             NodeKind::Expr(expr) => {
                 self.emit_header();
                 if let Some(rendered) = self.render_expr(expr)? {
@@ -163,10 +161,7 @@ impl GoEmitter {
             ItemKind::Expr(expr) => self.emit_expr_item(expr),
             ItemKind::Import(_) => Ok(()),
             _ => {
-                self.push_comment(&format!(
-                    "unsupported item in Go output: {:?}",
-                    item.kind()
-                ));
+                self.push_comment(&format!("unsupported item in Go output: {:?}", item.kind()));
                 Ok(())
             }
         }
@@ -218,13 +213,15 @@ impl GoEmitter {
     }
 
     fn emit_const(&mut self, def: &ItemDefConst) -> Result<()> {
-        let keyword = if def.mutable == Some(true) { "var" } else { "const" };
+        let keyword = if def.mutable == Some(true) {
+            "var"
+        } else {
+            "const"
+        };
         let value = match self.render_expr(def.value.as_ref())? {
             Some(rendered) => rendered,
             None => {
-                self.push_comment(&format!(
-                    "unsupported initializer for {}", def.name.name
-                ));
+                self.push_comment(&format!("unsupported initializer for {}", def.name.name));
                 "0".to_string()
             }
         };

--- a/crates/fp-golang/src/tests.rs
+++ b/crates/fp-golang/src/tests.rs
@@ -52,7 +52,10 @@ func main() {
 fn serialize_basic_go_ast() {
     let fields = vec![
         StructuralField::new(Ident::new("Name"), Ty::Primitive(TypePrimitive::String)),
-        StructuralField::new(Ident::new("Age"), Ty::Primitive(TypePrimitive::Int(fp_core::ast::TypeInt::I64))),
+        StructuralField::new(
+            Ident::new("Age"),
+            Ty::Primitive(TypePrimitive::Int(fp_core::ast::TypeInt::I64)),
+        ),
     ];
     let mut user_struct = ItemDefStruct::new(Ident::new("User"), fields);
     user_struct.visibility = fp_core::ast::Visibility::Public;
@@ -81,7 +84,9 @@ fn serialize_basic_go_ast() {
 
     let node = Node::from(NodeKind::File(file));
     let serializer = GoSerializer::default();
-    let output = serializer.serialize_node(&node).expect("serialize should succeed");
+    let output = serializer
+        .serialize_node(&node)
+        .expect("serialize should succeed");
 
     assert!(output.contains("package main"));
     assert!(output.contains("type User struct"));

--- a/crates/fp-interpret/src/const_eval.rs
+++ b/crates/fp-interpret/src/const_eval.rs
@@ -5,8 +5,8 @@ use fp_core::ast::{
     register_threadlocal_serializer, AstSerializer, Ident, Item, ItemKind, MacroExpansionParser,
     Module, Node, Ty, Value, Visibility,
 };
-use fp_core::context::SharedScopedContext;
 use fp_core::cfg::TargetEnv;
+use fp_core::context::SharedScopedContext;
 use fp_core::diagnostics::Diagnostic;
 use fp_core::error::Result as CoreResult;
 use fp_core::intrinsics::IntrinsicNormalizer;

--- a/crates/fp-interpret/src/engine/eval_expr.rs
+++ b/crates/fp-interpret/src/engine/eval_expr.rs
@@ -2727,7 +2727,9 @@ impl<'ctx> AstInterpreter<'ctx> {
                 Err(flow) => return flow,
             };
             if let Value::Map(map) = &receiver.value {
-                return RuntimeFlow::Value(Value::bool(map.entries.iter().any(|entry| entry.key == key)));
+                return RuntimeFlow::Value(Value::bool(
+                    map.entries.iter().any(|entry| entry.key == key),
+                ));
             }
         }
 

--- a/crates/fp-interpret/src/engine/mod.rs
+++ b/crates/fp-interpret/src/engine/mod.rs
@@ -18,14 +18,14 @@ use fp_core::ast::{
     ItemKind, MacroDelimiter, MacroGroup, MacroInvocation, MacroToken, MacroTokenTree, Node,
     NodeKind, Path, QuoteFragmentKind, QuoteTokenValue, StmtLet, StructuralField, Ty, TypeAny,
     TypeArray, TypeBinaryOpKind, TypeFunction, TypeInt, TypePrimitive, TypeQuote, TypeReference,
-    TypeSlice, TypeStruct, TypeStructural, TypeTokenStream, TypeTuple, TypeUnit, TypeVec,
-    Value, ValueField, ValueFunction, ValueList, ValueStruct, ValueStructural, ValueTokenStream,
+    TypeSlice, TypeStruct, TypeStructural, TypeTokenStream, TypeTuple, TypeUnit, TypeVec, Value,
+    ValueField, ValueFunction, ValueList, ValueStruct, ValueStructural, ValueTokenStream,
     ValueTuple,
 };
 use fp_core::ast::{Ident, Name};
 use fp_core::ast::{Pattern, PatternKind};
-use fp_core::context::SharedScopedContext;
 use fp_core::cfg::TargetEnv;
+use fp_core::context::SharedScopedContext;
 use fp_core::diagnostics::{Diagnostic, DiagnosticLevel, DiagnosticManager};
 use fp_core::error::Result;
 use fp_core::intrinsics::{IntrinsicCallKind, IntrinsicNormalizer};
@@ -1246,7 +1246,9 @@ impl<'ctx> AstInterpreter<'ctx> {
             Value::Struct(value_struct) => {
                 self.extract_spawned_future_handle_from_struct(&value_struct.structural)
             }
-            Value::Structural(structural) => self.extract_spawned_future_handle_from_struct(structural),
+            Value::Structural(structural) => {
+                self.extract_spawned_future_handle_from_struct(structural)
+            }
             _ => None,
         }
     }
@@ -1263,7 +1265,10 @@ impl<'ctx> AstInterpreter<'ctx> {
         }
     }
 
-    fn extract_spawned_future_handle_from_struct(&self, structural: &ValueStructural) -> Option<u64> {
+    fn extract_spawned_future_handle_from_struct(
+        &self,
+        structural: &ValueStructural,
+    ) -> Option<u64> {
         let future = Ident::new("future");
         let field = structural.get_field(&future)?;
         match &field.value {
@@ -2043,7 +2048,8 @@ impl<'ctx> AstInterpreter<'ctx> {
             | Ty::ImplTraits(_)
             | Ty::Value(_)
             | Ty::Nothing(_)
-            | Ty::AnyBox(_) | Ty::RawPtr(_) => {}
+            | Ty::AnyBox(_)
+            | Ty::RawPtr(_) => {}
         }
     }
 
@@ -4177,7 +4183,8 @@ impl<'ctx> AstInterpreter<'ctx> {
             | Ty::Type(_)
             | Ty::Value(_)
             | Ty::TypeBinaryOp(_)
-            | Ty::AnyBox(_) | Ty::RawPtr(_) => ty.clone(),
+            | Ty::AnyBox(_)
+            | Ty::RawPtr(_) => ty.clone(),
         }
     }
 
@@ -6240,7 +6247,10 @@ impl<'ctx> AstInterpreter<'ctx> {
     }
 
     fn path_segments<'a>(&self, path: &'a Path) -> Vec<&'a str> {
-        path.segments.iter().map(|segment| segment.as_str()).collect()
+        path.segments
+            .iter()
+            .map(|segment| segment.as_str())
+            .collect()
     }
 
     fn handle_import(&mut self, import: &ItemImport) {
@@ -6552,8 +6562,11 @@ impl<'ctx> AstInterpreter<'ctx> {
     }
 
     fn module_alias_from_spec(&self, spec: &str) -> Option<String> {
-        self.parse_symbol_path(spec)
-            .and_then(|path| path.segments.last().map(|segment| segment.as_str().to_string()))
+        self.parse_symbol_path(spec).and_then(|path| {
+            path.segments
+                .last()
+                .map(|segment| segment.as_str().to_string())
+        })
     }
 
     fn register_imported_symbol(

--- a/crates/fp-lang/src/ast/items.rs
+++ b/crates/fp-lang/src/ast/items.rs
@@ -7,9 +7,8 @@ use fp_core::ast::{
     ItemDefConst, ItemDefEnum, ItemDefFunction, ItemDefStatic, ItemDefStruct, ItemDefTrait,
     ItemDefType, ItemImpl, ItemImport, ItemImportGroup, ItemImportPath, ItemImportRename,
     ItemImportTree, ItemKind, ItemMacro, MacroDelimiter, MacroInvocation, Module, Name, Path,
-    QuoteFragmentKind, StructuralField, Ty, TypeBinaryOp, TypeBinaryOpKind, TypeBounds,
-    TypeEnum, TypeQuote, TypeStruct, Value, ValueNone,
-    Visibility,
+    QuoteFragmentKind, StructuralField, Ty, TypeBinaryOp, TypeBinaryOpKind, TypeBounds, TypeEnum,
+    TypeQuote, TypeStruct, Value, ValueNone, Visibility,
 };
 use fp_core::cst::CstCategory;
 use fp_core::module::path::PathPrefix;

--- a/crates/fp-lang/src/cst/expr.rs
+++ b/crates/fp-lang/src/cst/expr.rs
@@ -1457,9 +1457,7 @@ impl Parser {
                 self.bump_trivia_into(&mut children);
             }
             _ => {
-                return Err(self.error(
-                    "raw pointer types require `*const` or `*mut`",
-                ));
+                return Err(self.error("raw pointer types require `*const` or `*mut`"));
             }
         }
 

--- a/crates/fp-lang/src/cst/items.rs
+++ b/crates/fp-lang/src/cst/items.rs
@@ -1342,16 +1342,18 @@ fn parse_expr_prefix_from_tokens(input: &mut &[Token]) -> ModalResult<SyntaxNode
 #[allow(deprecated)] // ErrorKind required by winnow 0.6 FromExternalError API.
 fn parse_type_prefix_from_tokens(input: &mut &[Token], stops: &[&str]) -> ModalResult<SyntaxNode> {
     let (lexemes, lexeme_to_token_end) = lexemes_from_tokens_for_type(input);
-    let (node, consumed) = cst::parse_type_lexemes_prefix_to_cst(&lexemes, current_items_file(), stops)
-        .map_err(|err| {
-            ErrMode::Cut(
-                <ContextError as FromExternalError<Vec<Lexeme>, _>>::from_external_error(
-                    &lexemes,
-                    ErrorKind::Fail,
-                    err,
-                ),
-            )
-        })?;
+    let (node, consumed) =
+        cst::parse_type_lexemes_prefix_to_cst(&lexemes, current_items_file(), stops).map_err(
+            |err| {
+                ErrMode::Cut(
+                    <ContextError as FromExternalError<Vec<Lexeme>, _>>::from_external_error(
+                        &lexemes,
+                        ErrorKind::Fail,
+                        err,
+                    ),
+                )
+            },
+        )?;
 
     let consumed_tokens = if consumed == 0 {
         0

--- a/crates/fp-native/src/emit/aarch64.rs
+++ b/crates/fp-native/src/emit/aarch64.rs
@@ -622,7 +622,9 @@ fn encode_const_bytes(constant: &LirConstant, ty: &LirType) -> Result<Vec<u8>> {
             }
             Ok(out)
         }
-        _ => Err(Error::from("unsupported global initializer for native rodata")),
+        _ => Err(Error::from(
+            "unsupported global initializer for native rodata",
+        )),
     }
 }
 
@@ -632,10 +634,11 @@ fn const_to_u8(constant: &LirConstant) -> Result<u8> {
         LirConstant::UInt(value, _) => Ok(*value as u8),
         LirConstant::Bool(value) => Ok(if *value { 1 } else { 0 }),
         LirConstant::Null(_) | LirConstant::Undef(_) => Ok(0),
-        _ => Err(Error::from("unsupported global array element for native rodata")),
+        _ => Err(Error::from(
+            "unsupported global array element for native rodata",
+        )),
     }
 }
-
 
 enum BinOp {
     Add,
@@ -1148,7 +1151,9 @@ fn load_value(
             }
             if let LirConstant::GlobalRef(name, _, indices) = constant {
                 if indices.iter().any(|idx| *idx != 0) {
-                    return Err(Error::from("unsupported non-zero GlobalRef indices for aarch64"));
+                    return Err(Error::from(
+                        "unsupported non-zero GlobalRef indices for aarch64",
+                    ));
                 }
                 emit_load_symbol_addr(asm, dst, name.as_str(), 0)?;
                 return Ok(());
@@ -1719,7 +1724,9 @@ fn emit_store(
                     emit_store_to_sp(asm, Reg::X16, offset);
                     Ok(())
                 }
-                _ => Err(Error::from("unsupported array element size in constant store")),
+                _ => Err(Error::from(
+                    "unsupported array element size in constant store",
+                )),
             }
         };
         let store_elem_reg = |asm: &mut Assembler| -> Result<()> {
@@ -1740,7 +1747,9 @@ fn emit_store(
                     emit_store_to_reg(asm, Reg::X16, Reg::X9);
                     Ok(())
                 }
-                _ => Err(Error::from("unsupported array element size in constant store")),
+                _ => Err(Error::from(
+                    "unsupported array element size in constant store",
+                )),
             }
         };
         match address {
@@ -3459,9 +3468,7 @@ fn store_constant_aggregate_to_reg(
                     4 => emit_store32_to_reg(asm, Reg::X16, Reg::X9),
                     8 => emit_store_to_reg(asm, Reg::X16, Reg::X9),
                     _ => {
-                        return Err(Error::from(
-                            "unsupported aggregate field size in return",
-                        ));
+                        return Err(Error::from("unsupported aggregate field size in return"));
                     }
                 }
             }
@@ -3502,9 +3509,7 @@ fn store_constant_aggregate_to_reg(
                     4 => emit_store32_to_reg(asm, Reg::X16, Reg::X9),
                     8 => emit_store_to_reg(asm, Reg::X16, Reg::X9),
                     _ => {
-                        return Err(Error::from(
-                            "unsupported array element size in return",
-                        ));
+                        return Err(Error::from("unsupported array element size in return"));
                     }
                 }
             }

--- a/crates/fp-native/src/emit/codegen.rs
+++ b/crates/fp-native/src/emit/codegen.rs
@@ -28,7 +28,10 @@ pub fn emit_text_from_lir(
 
     for block in &func.basic_blocks {
         for inst in &block.instructions {
-            if let LirInstructionKind::Call { function: _, args, .. } = &inst.kind {
+            if let LirInstructionKind::Call {
+                function: _, args, ..
+            } = &inst.kind
+            {
                 if !args.iter().all(is_call_arg_value) {
                     return Err(Error::from(
                         "native emitter only supports register/constant/local/stack call args",

--- a/crates/fp-native/src/emit/x86_64.rs
+++ b/crates/fp-native/src/emit/x86_64.rs
@@ -439,7 +439,9 @@ fn encode_const_bytes(constant: &LirConstant, ty: &LirType) -> Result<Vec<u8>> {
             }
             Ok(out)
         }
-        _ => Err(Error::from("unsupported global initializer for native rodata")),
+        _ => Err(Error::from(
+            "unsupported global initializer for native rodata",
+        )),
     }
 }
 
@@ -449,10 +451,11 @@ fn const_to_u8(constant: &LirConstant) -> Result<u8> {
         LirConstant::UInt(value, _) => Ok(*value as u8),
         LirConstant::Bool(value) => Ok(if *value { 1 } else { 0 }),
         LirConstant::Null(_) | LirConstant::Undef(_) => Ok(0),
-        _ => Err(Error::from("unsupported global array element for native rodata")),
+        _ => Err(Error::from(
+            "unsupported global array element for native rodata",
+        )),
     }
 }
-
 
 fn spill_arguments(
     asm: &mut Assembler,
@@ -1134,7 +1137,9 @@ fn load_value(
             }
             if let LirConstant::GlobalRef(name, _, indices) = constant {
                 if indices.iter().any(|idx| *idx != 0) {
-                    return Err(Error::from("unsupported non-zero GlobalRef indices for x86_64"));
+                    return Err(Error::from(
+                        "unsupported non-zero GlobalRef indices for x86_64",
+                    ));
                 }
                 emit_mov_symbol_addr(asm, dst, name.as_str(), 0)?;
                 return Ok(());
@@ -3708,7 +3713,7 @@ fn emit_store(
                 _ => {
                     return Err(Error::from(
                         "unsupported array element size in constant store",
-                    ))
+                    ));
                 }
             }
             Ok(())
@@ -4844,9 +4849,7 @@ fn store_constant_aggregate_to_reg(
                     4 => emit_mov_mr32(asm, base, dst, Reg::R10),
                     8 => emit_mov_mr64(asm, base, dst, Reg::R10),
                     _ => {
-                        return Err(Error::from(
-                            "unsupported aggregate field size in return",
-                        ));
+                        return Err(Error::from("unsupported aggregate field size in return"));
                     }
                 }
             }
@@ -4885,9 +4888,7 @@ fn store_constant_aggregate_to_reg(
                     4 => emit_mov_mr32(asm, base, offset, Reg::R10),
                     8 => emit_mov_mr64(asm, base, offset, Reg::R10),
                     _ => {
-                        return Err(Error::from(
-                            "unsupported array element size in return",
-                        ));
+                        return Err(Error::from("unsupported array element size in return"));
                     }
                 }
             }

--- a/crates/fp-native/src/link/coff.rs
+++ b/crates/fp-native/src/link/coff.rs
@@ -877,7 +877,9 @@ pub fn emit_executable_pe64(path: &Path, arch: TargetArch, plan: &EmitPlan) -> R
         if name == ".rodata" {
             Ok(rodata_addr.wrapping_add(addend as u64))
         } else if let Some(offset) = plan.rodata_symbols.get(name) {
-            Ok(rodata_addr.wrapping_add(*offset).wrapping_add(addend as u64))
+            Ok(rodata_addr
+                .wrapping_add(*offset)
+                .wrapping_add(addend as u64))
         } else if let Some(offset) = plan.symbols.get(name) {
             Ok(text_addr.wrapping_add(*offset).wrapping_add(addend as u64))
         } else {

--- a/crates/fp-native/src/link/elf.rs
+++ b/crates/fp-native/src/link/elf.rs
@@ -351,7 +351,9 @@ pub fn emit_executable_elf64(path: &Path, arch: TargetArch, plan: &EmitPlan) -> 
         if name == ".rodata" {
             Ok(rodata_addr.wrapping_add(addend as u64))
         } else if let Some(offset) = plan.rodata_symbols.get(name) {
-            Ok(rodata_addr.wrapping_add(*offset).wrapping_add(addend as u64))
+            Ok(rodata_addr
+                .wrapping_add(*offset)
+                .wrapping_add(addend as u64))
         } else if let Some(offset) = plan.symbols.get(name) {
             Ok(text_addr.wrapping_add(*offset).wrapping_add(addend as u64))
         } else {

--- a/crates/fp-native/src/link/macho.rs
+++ b/crates/fp-native/src/link/macho.rs
@@ -712,7 +712,9 @@ pub fn emit_executable_macho(path: &Path, arch: TargetArch, plan: &EmitPlan) -> 
         if name == ".rodata" {
             Ok(rodata_addr.wrapping_add(addend as u64))
         } else if let Some(offset) = plan.rodata_symbols.get(name) {
-            Ok(rodata_addr.wrapping_add(*offset).wrapping_add(addend as u64))
+            Ok(rodata_addr
+                .wrapping_add(*offset)
+                .wrapping_add(addend as u64))
         } else if let Some(offset) = plan.symbols.get(name) {
             Ok(text_addr.wrapping_add(*offset).wrapping_add(addend as u64))
         } else {

--- a/crates/fp-prql/src/compile.rs
+++ b/crates/fp-prql/src/compile.rs
@@ -19,11 +19,7 @@ pub fn compile_prql(
 
     if let QueryKind::Prql(prql) = &document.kind {
         target = prql.target.clone();
-        statements = prql
-            .compiled
-            .iter()
-            .map(|stmt| stmt.text.clone())
-            .collect();
+        statements = prql.compiled.iter().map(|stmt| stmt.text.clone()).collect();
     }
 
     Ok(PrqlCompileResult { target, statements })

--- a/crates/fp-prql/src/lib.rs
+++ b/crates/fp-prql/src/lib.rs
@@ -4,8 +4,8 @@ pub mod compile;
 pub mod dialect;
 pub mod frontend;
 
+pub use compile::{compile_prql, PrqlCompileResult};
 pub use fp_core::query::SqlDialect;
-pub use compile::{PrqlCompileResult, compile_prql};
 pub use frontend::PrqlFrontend;
 
 /// Canonical language identifier for PRQL sources.

--- a/crates/fp-prql/src/tests.rs
+++ b/crates/fp-prql/src/tests.rs
@@ -32,13 +32,11 @@ from employees
         other => panic!("expected query node, found {other:?}"),
     }
 
-    assert!(
-        result
-            .diagnostics
-            .get_diagnostics()
-            .iter()
-            .all(|d| d.level != DiagnosticLevel::Error)
-    );
+    assert!(result
+        .diagnostics
+        .get_diagnostics()
+        .iter()
+        .all(|d| d.level != DiagnosticLevel::Error));
 }
 
 #[test]

--- a/crates/fp-sql/src/lib.rs
+++ b/crates/fp-sql/src/lib.rs
@@ -12,13 +12,11 @@ pub mod sql_ast;
 /// Canonical language identifier for SQL sources.
 pub const SQL: &str = "sql";
 
-pub use frontend::SqlFrontend;
 pub use dialect::{parse_sql_dialect, sqlparser_dialect};
+pub use frontend::SqlFrontend;
 pub use select::extract_select_projection;
 pub use split::{
-    ensure_engine_clause,
-    replace_engine_case_insensitive,
-    split_statements,
+    ensure_engine_clause, replace_engine_case_insensitive, split_statements,
     strip_leading_sql_comments,
 };
 

--- a/crates/fp-sql/src/select.rs
+++ b/crates/fp-sql/src/select.rs
@@ -118,8 +118,7 @@ mod tests {
 
     #[test]
     fn detects_from_followed_by_quote() {
-        let projection = extract_select_projection("SELECT a FROM'table'")
-            .expect("projection");
+        let projection = extract_select_projection("SELECT a FROM'table'").expect("projection");
         assert_eq!(projection.trim(), "a");
     }
 }

--- a/crates/fp-sql/src/split.rs
+++ b/crates/fp-sql/src/split.rs
@@ -45,9 +45,7 @@ pub fn replace_engine_case_insensitive(sql: &str, engine: &str) -> String {
         cursor += 1;
     }
     let start = cursor;
-    while cursor < bytes.len()
-        && (bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_')
-    {
+    while cursor < bytes.len() && (bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_') {
         cursor += 1;
     }
 

--- a/crates/fp-sql/src/tests.rs
+++ b/crates/fp-sql/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
-use fp_core::frontend::LanguageFrontend;
 use fp_core::diagnostics::DiagnosticLevel;
+use fp_core::frontend::LanguageFrontend;
 
 #[test]
 fn parses_basic_select() {
@@ -23,13 +23,11 @@ fn parses_basic_select() {
         other => panic!("expected query node, found {other:?}"),
     }
 
-    assert!(
-        !result
-            .diagnostics
-            .get_diagnostics()
-            .iter()
-            .any(|d| d.level == DiagnosticLevel::Error)
-    );
+    assert!(!result
+        .diagnostics
+        .get_diagnostics()
+        .iter()
+        .any(|d| d.level == DiagnosticLevel::Error));
 }
 
 #[test]

--- a/crates/fp-toml/src/lib.rs
+++ b/crates/fp-toml/src/lib.rs
@@ -123,11 +123,7 @@ fn value_to_toml(value: &Value) -> CoreResult<TomlValue> {
             for entry in &map.entries {
                 let key = match &entry.key {
                     Value::String(s) => s.value.clone(),
-                    _ => {
-                        return Err(CoreError::from(
-                            "toml serializer expects string keys",
-                        ))
-                    }
+                    _ => return Err(CoreError::from("toml serializer expects string keys")),
                 };
                 let value = value_to_toml(&entry.value)?;
                 table.insert(key, value);

--- a/crates/fp-typescript/src/frontend.rs
+++ b/crates/fp-typescript/src/frontend.rs
@@ -6,7 +6,7 @@ use fp_core::ast::{
     DecimalType, EnumTypeVariant, Expr, ExprBlock, ExprInvoke, ExprInvokeTarget, ExprKind, File,
     FunctionParam, FunctionSignature, Ident, Item, ItemDeclConst, ItemDefConst, ItemDefEnum,
     ItemDefFunction, ItemDefStruct, ItemDefType, ItemImport, ItemImportGroup, ItemImportPath,
-    ItemImportRename, ItemImportTree, ItemKind, Name, Module as AstModule, Node, NodeKind,
+    ItemImportRename, ItemImportTree, ItemKind, Module as AstModule, Name, Node, NodeKind,
     StructuralField, Ty, TypeEnum, TypeInt, TypePrimitive, TypeStruct, TypeStructural, TypeTuple,
     TypeVec, Value, Visibility,
 };

--- a/crates/fp-typescript/src/ts/serializer.rs
+++ b/crates/fp-typescript/src/ts/serializer.rs
@@ -160,8 +160,7 @@ impl ScriptEmitter {
             if let Err(err) = self.emit_function(function_item) {
                 self.push_line(&format!(
                     "// skipped unsupported function {}: {}",
-                    function_item.name,
-                    err
+                    function_item.name, err
                 ));
             }
             return Ok(());

--- a/crates/fp-typing/src/lib.rs
+++ b/crates/fp-typing/src/lib.rs
@@ -1,8 +1,8 @@
 use fp_core::config;
 use std::collections::{HashMap, HashSet};
 
-pub mod typing;
 pub mod runtime_types;
+pub mod typing;
 pub use runtime_types::{materialize_type_with_hooks, type_from_value, TypeMaterializeHooks};
 pub use typing::types::{TypingDiagnostic, TypingDiagnosticLevel, TypingOutcome};
 

--- a/crates/fp-typing/src/runtime_types.rs
+++ b/crates/fp-typing/src/runtime_types.rs
@@ -136,14 +136,38 @@ fn key_terminal_segment(key: &str) -> &str {
 
 pub fn builtin_type_bindings() -> HashMap<String, Ty> {
     let mut bindings = HashMap::new();
-    bindings.insert("i64".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::I64)));
-    bindings.insert("u64".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::U64)));
-    bindings.insert("i32".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::I32)));
-    bindings.insert("u32".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::U32)));
-    bindings.insert("i16".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::I16)));
-    bindings.insert("u16".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::U16)));
-    bindings.insert("i8".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::I8)));
-    bindings.insert("u8".to_string(), Ty::Primitive(TypePrimitive::Int(TypeInt::U8)));
+    bindings.insert(
+        "i64".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::I64)),
+    );
+    bindings.insert(
+        "u64".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::U64)),
+    );
+    bindings.insert(
+        "i32".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::I32)),
+    );
+    bindings.insert(
+        "u32".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::U32)),
+    );
+    bindings.insert(
+        "i16".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::I16)),
+    );
+    bindings.insert(
+        "u16".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::U16)),
+    );
+    bindings.insert(
+        "i8".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::I8)),
+    );
+    bindings.insert(
+        "u8".to_string(),
+        Ty::Primitive(TypePrimitive::Int(TypeInt::U8)),
+    );
     bindings.insert(
         "isize".to_string(),
         Ty::Primitive(TypePrimitive::Int(TypeInt::I64)),
@@ -164,7 +188,9 @@ pub fn infer_value_ty(value: &Value) -> Option<Ty> {
         Value::Int(_) => Some(Ty::Primitive(TypePrimitive::Int(TypeInt::I64))),
         Value::BigInt(_) => Some(Ty::Primitive(TypePrimitive::Int(TypeInt::BigInt))),
         Value::Decimal(_) => Some(Ty::Primitive(TypePrimitive::Decimal(DecimalType::F64))),
-        Value::BigDecimal(_) => Some(Ty::Primitive(TypePrimitive::Decimal(DecimalType::BigDecimal))),
+        Value::BigDecimal(_) => Some(Ty::Primitive(TypePrimitive::Decimal(
+            DecimalType::BigDecimal,
+        ))),
         Value::Bool(_) => Some(Ty::Primitive(TypePrimitive::Bool)),
         Value::Char(_) => Some(Ty::Primitive(TypePrimitive::Char)),
         Value::String(_) => Some(Ty::Primitive(TypePrimitive::String)),
@@ -208,11 +234,12 @@ pub fn materialize_type_with_hooks(ty: Ty, hooks: &mut impl TypeMaterializeHooks
 
     match expr.kind() {
         ExprKind::Name(locator) => hooks.resolve_name(locator).unwrap_or(Ty::Expr(expr)),
-        ExprKind::ConstBlock(_) => hooks.eval_const_expr(expr.as_mut()).unwrap_or(Ty::Expr(expr)),
+        ExprKind::ConstBlock(_) => hooks
+            .eval_const_expr(expr.as_mut())
+            .unwrap_or(Ty::Expr(expr)),
         _ => Ty::Expr(expr),
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/fp-typing/src/typing/unify.rs
+++ b/crates/fp-typing/src/typing/unify.rs
@@ -557,9 +557,7 @@ impl<'ctx> AstTypeInferencer<'ctx> {
                 }
                 self.unify(a_func.ret, b_func.ret)
             }
-            (TypeTerm::RawPtr(_, m1), TypeTerm::RawPtr(_, m2))
-                if matches!((m1, m2), (Some(a), Some(b)) if a != b) =>
-            {
+            (TypeTerm::RawPtr(_, m1), TypeTerm::RawPtr(_, m2)) if matches!((m1, m2), (Some(a), Some(b)) if a != b) => {
                 Err(self.error_with_current_span("raw pointer mutability mismatch"))
             }
             (TypeTerm::Slice(a), TypeTerm::Slice(b))

--- a/crates/magnet/src/manager.rs
+++ b/crates/magnet/src/manager.rs
@@ -82,7 +82,10 @@ impl ManifestManager {
                 warn!("No matching crates found for dependency '{}'", name);
                 return Ok(dep);
             }
-            dep.path = Some(diff_path(manifest_root_path, &matching_crates[0].root_path)?);
+            dep.path = Some(diff_path(
+                manifest_root_path,
+                &matching_crates[0].root_path,
+            )?);
             dep.nexus = None;
             dep.workspace = None;
             return Ok(dep);


### PR DESCRIPTION
Applies rustfmt across the workspace to satisfy CI formatting checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied cargo fmt across all crates to satisfy CI formatting checks. No functional changes.

- **Refactors**
  - Reordered imports and module exports, reflowed long expressions, and normalized whitespace.
  - Reformatted backends and emitters (Cranelift/native), language frontends (SQL/PRQL/Go/Python/TypeScript), CLI, and tests to pass rustfmt in CI.

<sup>Written for commit 314c624a9d4a2e383e8df4e3106c2467c9977d83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

